### PR TITLE
Should not call setup here

### DIFF
--- a/fprime-arduino.cmake
+++ b/fprime-arduino.cmake
@@ -19,5 +19,3 @@ add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Arduino/Drv/I2cDriver")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Arduino/Drv/SpiDriver")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Arduino/Drv/TcpClient")
 add_fprime_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Arduino/Drv/HardwareRateDriver")
-
-setup_arduino_libraries()


### PR DESCRIPTION
This was a mistake I forgot to get rid of. This is pretty urgent as it breaks linking to arduino libraries.