### PR TITLE
Urgent Fix: basic timer bug

### DIFF
--- a/Arduino/Drv/HardwareRateDriver/HardwareRateDriverBasic.cpp
+++ b/Arduino/Drv/HardwareRateDriver/HardwareRateDriverBasic.cpp
@@ -16,7 +16,7 @@ void HardwareRateDriver::cycle() {
     if((micros() - last_us) >= interval_us)
     {
         this->s_timerISR();
-        last_us += m_interval;
+        last_us += interval_us;
     }
 }
 

--- a/cmake/toolchain/esp32.cmake
+++ b/cmake/toolchain/esp32.cmake
@@ -13,6 +13,6 @@ set(CMAKE_C_COMPILER_WORKS 1)
 set(CMAKE_CXX_COMPILER_WORKS 1)
 
 set(ARDUINO_FQBN "esp32:esp32:esp32")
-add_compile_options(-DNO_ONBOARD_LED)
+add_compile_options(-DNO_ONBOARD_LED -DUSE_BASIC_TIMER)
 # Run the base arduino setup which should detect settings!
 include("${CMAKE_CURRENT_LIST_DIR}/support/arduino-support.cmake")

--- a/cmake/toolchain/featherM0.cmake
+++ b/cmake/toolchain/featherM0.cmake
@@ -13,5 +13,6 @@ set(FPRIME_USE_BAREMETAL_SCHEDULER ON)
 set(ARDUINO_BUILD_PROPERTIES)
 
 set(ARDUINO_FQBN "adafruit:samd:adafruit_feather_m0")
+add_compile_options(-DUSE_BASIC_TIMER)
 # Run the base arduino setup which should detect settings!
 include("${CMAKE_CURRENT_LIST_DIR}/support/arduino-support.cmake")

--- a/cmake/toolchain/featherrp2040rfm.cmake
+++ b/cmake/toolchain/featherrp2040rfm.cmake
@@ -9,7 +9,7 @@ set(CMAKE_SYSTEM_PROCESSOR "arm")
 set(CMAKE_CROSSCOMPILING 1)
 set(FPRIME_USE_BAREMETAL_SCHEDULER ON)
 
-
 set(ARDUINO_FQBN "rp2040:rp2040:adafruit_feather_rfm")
+add_compile_options(-DUSE_BASIC_TIMER)
 # Run the base arduino setup which should detect settings!
 include("${CMAKE_CURRENT_LIST_DIR}/support/arduino-support.cmake")

--- a/cmake/toolchain/rpipico.cmake
+++ b/cmake/toolchain/rpipico.cmake
@@ -10,5 +10,6 @@ set(CMAKE_CROSSCOMPILING 1)
 set(FPRIME_USE_BAREMETAL_SCHEDULER ON)
 
 set(ARDUINO_FQBN "rp2040:rp2040:rpipico")
+add_compile_options(-DUSE_BASIC_TIMER)
 # Run the base arduino setup which should detect settings!
 include("${CMAKE_CURRENT_LIST_DIR}/support/arduino-support.cmake")

--- a/cmake/toolchain/rpipicow.cmake
+++ b/cmake/toolchain/rpipicow.cmake
@@ -10,5 +10,6 @@ set(CMAKE_CROSSCOMPILING 1)
 set(FPRIME_USE_BAREMETAL_SCHEDULER ON)
 set(ARDUINO_WIFI_ENABLED ON)
 set(ARDUINO_FQBN "rp2040:rp2040:rpipicow")
+add_compile_options(-DUSE_BASIC_TIMER)
 # Run the base arduino setup which should detect settings!
 include("${CMAKE_CURRENT_LIST_DIR}/support/arduino-support.cmake")

--- a/cmake/toolchain/thingplusrp2040.cmake
+++ b/cmake/toolchain/thingplusrp2040.cmake
@@ -9,7 +9,7 @@ set(CMAKE_SYSTEM_PROCESSOR "arm")
 set(CMAKE_CROSSCOMPILING 1)
 set(FPRIME_USE_BAREMETAL_SCHEDULER ON)
 
-
 set(ARDUINO_FQBN "rp2040:rp2040:sparkfun_thingplusrp2040")
+add_compile_options(-DUSE_BASIC_TIMER)
 # Run the base arduino setup which should detect settings!
 include("${CMAKE_CURRENT_LIST_DIR}/support/arduino-support.cmake")


### PR DESCRIPTION
Basic Hardware Rate Driver implementation used millisecond interval instead of microsecond interval. So everything was driven at 1000x (?) speed.

The CMakeLists.txt in `HardwareRateDriver` no longer has `set(COMPILE_DEFINITIONS "USE_BASIC_TIMER")`. Instead, add the flag within the board .cmake files.