### PR TITLE
Add Os File Implementation using `<SD.h>`

### DIFF
--- a/Arduino/Os/CMakeLists.txt
+++ b/Arduino/Os/CMakeLists.txt
@@ -8,6 +8,12 @@
 restrict_platforms(ArduinoFw)
 add_custom_target("${FPRIME_CURRENT_MODULE}")
 
+arduino_lib_installed("SD" LIB_SD_INSTALLED)
+
 # Set up Arduino implementations
 add_fprime_supplied_os_module(Console Arduino)
 add_fprime_supplied_os_module(RawTime Arduino)
+if (LIB_SD_INSTALLED)
+    target_use_arduino_libraries("SD")
+    add_fprime_supplied_os_module("File;FileSystem;Directory" Arduino)
+endif()

--- a/Arduino/Os/DefaultFile.cpp
+++ b/Arduino/Os/DefaultFile.cpp
@@ -1,0 +1,39 @@
+// ======================================================================
+// \title Os/Arduino/DefaultFile.cpp
+// \brief sets default Os::File to no-op Arduino implementation via linker
+// ======================================================================
+#include "Arduino/Os/File.hpp"
+#include "Arduino/Os/FileSystem.hpp"
+#include "Arduino/Os/Directory.hpp"
+#include "Os/Delegate.hpp"
+namespace Os {
+
+//! \brief get a delegate for FileInterface that intercepts calls for Arduino file usage
+//! \param aligned_new_memory: aligned memory to fill
+//! \param to_copy: pointer to copy-constructor input
+//! \return: pointer to delegate
+FileInterface *FileInterface::getDelegate(FileHandleStorage& aligned_placement_new_memory, const FileInterface* to_copy) {
+    return Os::Delegate::makeDelegate<FileInterface, Os::Arduino::ArduinoFile>(
+            aligned_placement_new_memory, to_copy
+    );
+}
+
+//! \brief get a delegate for FileSystemInterface that intercepts calls for Arduino fileSystem usage
+//! \param aligned_new_memory: aligned memory to fill
+//! \param to_copy: pointer to copy-constructor input
+//! \return: pointer to delegate
+FileSystemInterface *FileSystemInterface::getDelegate(FileSystemHandleStorage& aligned_placement_new_memory) {
+    return Os::Delegate::makeDelegate<FileSystemInterface, Os::Arduino::ArduinoFileSystem>(
+        aligned_placement_new_memory
+    );
+}
+
+//! \brief get a delegate for DirectoryInterface that intercepts calls for Arduino Directory usage
+//! \param aligned_new_memory: aligned memory to fill
+//! \return: pointer to delegate
+DirectoryInterface *DirectoryInterface::getDelegate(DirectoryHandleStorage& aligned_placement_new_memory) {
+    return Os::Delegate::makeDelegate<DirectoryInterface, Os::Arduino::ArduinoDirectory>(
+        aligned_placement_new_memory
+    );
+}
+}

--- a/Arduino/Os/Directory.cpp
+++ b/Arduino/Os/Directory.cpp
@@ -1,0 +1,148 @@
+// ======================================================================
+// \title Os/Arduino/Directory.cpp
+// \brief Arduino implementation for Os::Directory
+// ======================================================================
+#include "Arduino/Os/Directory.hpp"
+#include <Fw/Types/Assert.hpp>
+#include <Fw/Types/StringUtils.hpp>
+
+namespace Os {
+namespace Arduino {
+
+ArduinoDirectory::~ArduinoDirectory() {
+    this->close();
+}
+
+ArduinoDirectory::Status ArduinoDirectory::open(const char* path, OpenMode mode) {
+    ::File dir;
+
+    switch (mode) {
+        case OpenMode::READ:
+            // Check if path exists
+            if (!SD.exists(path)) {
+                return Status::DOESNT_EXIST;
+            }
+
+            // Open path
+            dir = SD.open(path);
+
+            // Handle error opening path
+            if (!dir) {
+                return Status::OTHER_ERROR;
+            }
+
+            // Check if path is a directory
+            if (!dir.isDirectory()) {
+                dir.close();
+                return Status::NOT_DIR;
+            }
+
+            // Store file descriptor
+            this->m_handle.m_dir = dir;
+            break;
+        case OpenMode::CREATE_IF_MISSING:
+            // If path does not exist, create it
+            if (!SD.exists(path) && !SD.mkdir(path)) {
+                return Status::OTHER_ERROR;
+            }
+
+            // Open path
+            dir = SD.open(path);
+
+            // Handle error opening path
+            if (!dir) {
+                return Status::OTHER_ERROR;
+            }
+
+            // Check if path is a directory
+            if (!dir.isDirectory()) {
+                dir.close();
+                return Status::NOT_DIR;
+            }
+
+            // Store file descriptor
+            this->m_handle.m_dir = dir;
+            break;
+        case OpenMode::CREATE_EXCLUSIVE:
+            // Check if path exists. If it does, return error
+            if (SD.exists(path)) {
+                return Status::ALREADY_EXISTS;
+            }
+
+            // Create directory
+            if (!SD.mkdir(path)) {
+                return Status::OTHER_ERROR;
+            }
+
+            // Open path
+            dir = SD.open(path);
+
+            // Handle error opening path
+            if (!dir) {
+                return Status::DOESNT_EXIST;
+            }
+
+            // Check if path is a directory
+            if (!dir.isDirectory()) {
+                dir.close();
+                return Status::NOT_DIR;
+            }
+
+            // Store file descriptor
+            this->m_handle.m_dir = dir;
+            break;
+        default:
+            return Status::OTHER_ERROR;
+    }
+
+    return Status::OP_OK;
+}
+
+ArduinoDirectory::Status ArduinoDirectory::rewind() {
+    return Status::NOT_SUPPORTED;
+}
+
+ArduinoDirectory::Status ArduinoDirectory::read(char* fileNameBuffer, FwSizeType bufSize) {
+    FW_ASSERT(fileNameBuffer);
+
+    if (!this->m_handle.m_dir) {
+        return Status::NOT_OPENED;
+    }
+
+    ::File fd;
+    // Open next file
+    while ((fd = this->m_handle.m_dir.openNextFile())) {
+        // Check if open was successful. If not, then no entries in directory
+        if (!fd) {
+            return Status::NO_MORE_FILES;
+        }
+
+        // Check if entry is a directory. If it is, skip it
+        if (fd.isDirectory()) {
+            fd.close();
+            continue;
+        }
+
+        // Opened next file. Break loop
+        break;
+    }
+
+    (void)Fw::StringUtils::string_copy(fileNameBuffer, fd.name(), bufSize);
+
+    this->close();
+    return Status::OP_OK;
+}
+
+void ArduinoDirectory::close() {
+    if (this->m_handle.m_dir) {
+        this->m_handle.m_dir.close();
+        this->m_handle.m_dir = 0;
+    }
+}
+
+DirectoryHandle* ArduinoDirectory::getHandle() {
+    return &this->m_handle;
+}
+
+}  // namespace Arduino
+}  // namespace Os

--- a/Arduino/Os/Directory.cpp
+++ b/Arduino/Os/Directory.cpp
@@ -129,7 +129,7 @@ ArduinoDirectory::Status ArduinoDirectory::read(char* fileNameBuffer, FwSizeType
 
     (void)Fw::StringUtils::string_copy(fileNameBuffer, fd.name(), bufSize);
 
-    this->close();
+    fd.close();
     return Status::OP_OK;
 }
 

--- a/Arduino/Os/Directory.hpp
+++ b/Arduino/Os/Directory.hpp
@@ -1,0 +1,89 @@
+// ======================================================================
+// \title Os/Arduino/Directory.hpp
+// \brief Arduino definitions for Os::Directory
+// ======================================================================
+#ifndef OS_ARDUINO_DIRECTORY_HPP
+#define OS_ARDUINO_DIRECTORY_HPP
+
+#include "Os/Directory.hpp"
+#include <SD.h>
+
+namespace Os {
+namespace Arduino {
+
+struct ArduinoDirectoryHandle : public DirectoryHandle {
+  ::File m_dir = 0;
+};
+
+//! \brief Arduino implementation of Os::Directory
+//!
+//! Arduino implementation of `DirectoryInterface` for use as a delegate class handling error-only file operations.
+//!
+class ArduinoDirectory : public DirectoryInterface {
+  public:
+    //! \brief constructor
+    ArduinoDirectory() = default;
+
+    //! \brief destructor
+    ~ArduinoDirectory();
+
+    //! \brief return the underlying Directory handle (implementation specific)
+    //! \return internal Directory handle representation
+    DirectoryHandle* getHandle() override;
+
+    // ------------------------------------------------------------
+    // Implementation-specific Directory member functions
+    // ------------------------------------------------------------
+
+    //! \brief Open or create a directory
+    //!
+    //! Using the path provided, this function will open or create a directory. 
+    //! Use OpenMode::READ to open an existing directory and error if the directory is not found
+    //! Use OpenMode::CREATE_IF_MISSING to open a directory, creating the directory if it doesn't exist
+    //! Use OpenMode::CREATE_EXCLUSIVE to open a directory, creating the directory and erroring if it already exists
+    //!
+    //! It is invalid to pass `nullptr` as the path.
+    //! It is invalid to supply `mode` as a non-enumerated value.
+    //!
+    //! \param path: path of directory to open
+    //! \param mode: enum (READ, CREATE_IF_MISSING, CREATE_EXCLUSIVE). See notes above for more information
+    //! \return status of the operation
+    Status open(const char* path, OpenMode mode) override;
+
+    //! \brief Check if Directory is open or not
+    //! \return true if Directory is open, false otherwise
+    bool isOpen();
+
+    //! \brief Rewind directory stream
+    //!
+    //! Each read operation moves the seek position forward. This function resets the seek position to the beginning.
+    //!
+    //! \return status of the operation
+    Status rewind() override;
+
+    //! \brief Get next filename from directory stream
+    //!
+    //! Writes at most buffSize characters of the file name to fileNameBuffer.
+    //! This function skips the current directory (.) and parent directory (..) entries.
+    //! Returns NO_MORE_FILES if there are no more files to read from the buffer.
+    //!
+    //! It is invalid to pass `nullptr` as fileNameBuffer.
+    //!
+    //! \param fileNameBuffer: buffer to store filename
+    //! \param buffSize: size of fileNameBuffer
+    //! \return status of the operation
+    Status read(char * fileNameBuffer, FwSizeType buffSize) override;
+
+
+    //! \brief Close directory
+    void close() override;
+
+
+  private:
+    //! Handle for ArduinoDirectory
+    ArduinoDirectoryHandle m_handle;
+};
+
+} // namespace Arduino
+} // namespace Os
+#endif // OS_ARDUINO_DIRECTORY_HPP

--- a/Arduino/Os/File.cpp
+++ b/Arduino/Os/File.cpp
@@ -1,0 +1,146 @@
+// ======================================================================
+// \title Os/Arduino/File.cpp
+// \brief Arduino implementation for Os::File
+// ======================================================================
+#include "Arduino/Os/File.hpp"
+#include <Fw/Types/Assert.hpp>
+
+namespace Os {
+namespace Arduino {
+
+ArduinoFile::~ArduinoFile() {
+    this->close();
+}
+
+ArduinoFile::Status ArduinoFile::open(const char* filepath, ArduinoFile::Mode open_mode, OverwriteType overwrite) {
+    PlatformIntType flags = 0;
+
+    switch (open_mode) {
+        case OPEN_READ:
+            flags = O_RDONLY;
+            break;
+        case OPEN_WRITE:
+            flags = O_WRONLY | O_CREAT;
+            break;
+        case OPEN_SYNC_WRITE:
+            flags = O_WRONLY | O_CREAT | O_SYNC;
+            break;
+        case OPEN_CREATE:
+            flags = O_WRONLY | O_CREAT | O_TRUNC | ((overwrite == ArduinoFile::OverwriteType::OVERWRITE) ? 0 : O_EXCL);
+            break;
+        case OPEN_APPEND:
+            flags = FILE_WRITE;
+            break;
+        default:
+            FW_ASSERT(0, open_mode);
+            break;
+    }
+
+    this->m_handle.m_fd = SD.open(filepath, flags);
+
+    if (!this->m_handle.m_fd) {
+        return Status::OTHER_ERROR;
+    }
+
+    return Status::OP_OK;
+}
+
+void ArduinoFile::close() {
+    if (this->m_handle.m_fd) {
+        this->m_handle.m_fd.close();
+        this->m_handle.m_fd = 0;
+    }
+}
+
+ArduinoFile::Status ArduinoFile::size(FwSignedSizeType& size_result) {
+    if (!this->m_handle.m_fd) {
+        size_result = 0;
+        return Status::NOT_OPENED;
+    }
+
+    size_result = this->m_handle.m_fd.size();
+
+    return Status::OP_OK;
+}
+
+ArduinoFile::Status ArduinoFile::position(FwSignedSizeType& position_result) {
+    if (!this->m_handle.m_fd) {
+        position_result = 0;
+        return Status::NOT_OPENED;
+    }
+
+    position_result = this->m_handle.m_fd.position();
+
+    return Status::OP_OK;
+}
+
+ArduinoFile::Status ArduinoFile::preallocate(FwSignedSizeType offset, FwSignedSizeType length) {
+    Status status = Status::NOT_SUPPORTED;
+    return status;
+}
+
+ArduinoFile::Status ArduinoFile::seek(FwSignedSizeType offset, SeekType seekType) {
+    if (!this->m_handle.m_fd) {
+        return Status::NOT_OPENED;
+    }
+
+    if (this->m_handle.m_fd.seek(offset)) {
+        return Status::OP_OK;
+    }
+
+    return Status::OTHER_ERROR;
+}
+
+ArduinoFile::Status ArduinoFile::flush() {
+    Status status = Status::NOT_SUPPORTED;
+    return status;
+}
+
+ArduinoFile::Status ArduinoFile::read(U8* buffer, FwSignedSizeType& size, ArduinoFile::WaitType wait) {
+    FW_ASSERT(buffer);
+
+    if (!this->m_handle.m_fd) {
+        size = 0;
+        return Status::NOT_OPENED;
+    }
+
+    if (size <= 0) {
+        size = 0;
+        return Status::BAD_SIZE;
+    }
+
+    if (this->m_handle.m_fd.available()) {
+        size = this->m_handle.m_fd.read(static_cast<U8*>(buffer), size);
+    } else {
+        size = 0;
+    }
+
+    return OP_OK;
+}
+
+ArduinoFile::Status ArduinoFile::write(const U8* buffer, FwSignedSizeType& size, ArduinoFile::WaitType wait) {
+    if (!this->m_handle.m_fd) {
+        size = 0;
+        return Status::NOT_OPENED;
+    }
+
+    if (size <= 0) {
+        size = 0;
+        return Status::BAD_SIZE;
+    }
+
+    size = this->m_handle.m_fd.write(buffer, size);
+
+    if (size == 0) {
+        return Status::OTHER_ERROR;
+    }
+
+    return OP_OK;
+}
+
+FileHandle* ArduinoFile::getHandle() {
+    return &this->m_handle;
+}
+
+}  // namespace Arduino
+}  // namespace Os

--- a/Arduino/Os/File.hpp
+++ b/Arduino/Os/File.hpp
@@ -1,0 +1,149 @@
+// ======================================================================
+// \title Os/Arduino/File.hpp
+// \brief Arduino file definitions for Os::File
+// ======================================================================
+#include "Os/File.hpp"
+#include <SD.h>
+
+#ifndef OS_ARDUINO_FILE_HPP
+#define OS_ARDUINO_FILE_HPP
+namespace Os {
+namespace Arduino {
+
+struct ArduinoFileHandle : public FileHandle {
+  ::File m_fd = 0;
+};
+
+//! \brief Arduino implementation of Os::File
+//!
+//! Arduino implementation of `FileInterface` for use as a delegate class handling error-only file operations.
+//!
+class ArduinoFile : public FileInterface {
+  public:
+    //! \brief constructor
+    //!
+    ArduinoFile() = default;
+
+    //! \brief destructor
+    //!
+    ~ArduinoFile() override;
+
+    // ------------------------------------
+    // Functions overrides
+    // ------------------------------------
+
+    //! \brief open file with supplied path and mode
+    //!
+    //! This implementation does nothing but return NOT_IMPLEMENTED.
+    //!
+    //! It is invalid to send `nullptr` as the path.
+    //! It is invalid to supply `mode` as a non-enumerated value.
+    //! It is invalid to supply `overwrite` as a non-enumerated value.
+    //!
+    //! \param path: c-string of path to open
+    //! \param mode: file operation mode
+    //! \param overwrite: overwrite existing file on create
+    //! \return: NOT_IMPLEMENTED
+    //!
+    Os::FileInterface::Status open(const char* path, Mode mode, OverwriteType overwrite) override;
+
+    //! \brief close the file, if not opened then do nothing
+    //!
+    //! This implementation does nothing.
+    //!
+    void close() override;
+
+    //! \brief get size of currently open file
+    //!
+    //! This implementation does nothing but return NOT_IMPLEMENTED.
+    //! \param size: output parameter for size.
+    //! \return NOT_IMPLEMENTED
+    //!
+    Status size(FwSignedSizeType& size_result) override;
+
+    //! \brief get file pointer position of the currently open file
+    //!
+    //! This implementation does nothing but return NOT_IMPLEMENTED.
+    //! \param position: output parameter for size.
+    //! \return NOT_IMPLEMENTED
+    //!
+    Status position(FwSignedSizeType& position_result) override;
+
+    //! \brief pre-allocate file storage
+    //!
+    //! This implementation does nothing but return NOT_IMPLEMENTED.
+    //!
+    //! It is invalid to pass a negative `offset`.
+    //! It is invalid to pass a negative `length`.
+    //!
+    //! \param offset: offset into file
+    //! \param length: length after offset to preallocate
+    //! \return NOT_IMPLEMENTED
+    //!
+    Status preallocate(FwSignedSizeType offset, FwSignedSizeType length) override;
+
+    //! \brief seek the file pointer to the given offset
+    //!
+    //! This implementation does nothing but return NOT_IMPLEMENTED.
+    //!
+    //! \param offset: offset to seek to
+    //! \param seekType: `ABSOLUTE` for seeking from beginning of file, `CURRENT` to use current position.
+    //! \return NOT_IMPLEMENTED
+    //!
+    Status seek(FwSignedSizeType offset, SeekType seekType) override;
+
+    //! \brief flush file contents to storage
+    //!
+    //! This implementation does nothing but return NOT_IMPLEMENTED.
+    //!
+    //! \return NOT_IMPLEMENTED
+    //!
+    Status flush() override;
+
+    //! \brief read data from this file into supplied buffer bounded by size
+    //!
+    //! This implementation does nothing but return NOT_IMPLEMENTED.
+    //!
+    //! It is invalid to pass `nullptr` to this function call.
+    //! It is invalid to pass a negative `size`.
+    //! It is invalid to supply wait as a non-enumerated value.
+    //!
+    //! \param buffer: memory location to store data read from file
+    //! \param size: size of data to read
+    //! \param wait: `WAIT` to wait for data, `NO_WAIT` to return what is currently available
+    //! \return NOT_IMPLEMENTED
+    //!
+    Status read(U8* buffer, FwSignedSizeType& size, WaitType wait) override;
+
+    //! \brief read data from this file into supplied buffer bounded by size
+    //!
+    //! This implementation does nothing but return NOT_IMPLEMENTED.
+    //!
+    //! It is invalid to pass `nullptr` to this function call.
+    //! It is invalid to pass a negative `size`.
+    //! It is invalid to supply wait as a non-enumerated value.
+    //!
+    //! \param buffer: memory location to store data read from file
+    //! \param size: size of data to read
+    //! \param wait: `WAIT` to wait for data to write to disk, `NO_WAIT` to return what is currently available
+    //! \return NOT_IMPLEMENTED
+    //!
+    Status write(const U8* buffer, FwSignedSizeType& size, WaitType wait) override;
+
+    //! \brief returns the raw file handle
+    //!
+    //! Gets the raw file handle from the implementation. Note: users must include the implementation specific
+    //! header to make any real use of this handle. Otherwise it//!must* be passed as an opaque type.
+    //!
+    //! \return raw file handle
+    //!
+    FileHandle* getHandle() override;
+
+  private:
+    //! File handle for ArduinoFile
+    ArduinoFileHandle m_handle;
+};
+
+}  // namespace Arduino
+}  // namespace Os
+#endif  // OS_Arduino_FILE_HPP

--- a/Arduino/Os/FileSystem.cpp
+++ b/Arduino/Os/FileSystem.cpp
@@ -1,0 +1,60 @@
+// ======================================================================
+// \title Os/Arduino/File.cpp
+// \brief Arduino implementation for Os::File
+// ======================================================================
+#include "Arduino/Os/FileSystem.hpp"
+
+namespace Os {
+namespace Arduino {
+
+ArduinoFileSystem::Status ArduinoFileSystem::_removeDirectory(const char* path) {
+    if (!SD.exists(path)) {
+        return Status::INVALID_PATH;
+    }
+    if (SD.rmdir(path)) {
+        return Status::OP_OK;
+    }
+    return Status::OTHER_ERROR;
+}
+
+ArduinoFileSystem::Status ArduinoFileSystem::_removeFile(const char* path) {
+    if (!SD.exists(path)) {
+        return Status::INVALID_PATH;
+    }
+    if (SD.remove(path)) {
+        return Status::OP_OK;
+    }
+    return Status::OTHER_ERROR;
+}
+
+ArduinoFileSystem::Status ArduinoFileSystem::_rename(const char* originPath, const char* destPath) {
+    Status stat;
+    
+    stat = Os::FileSystem::copyFile(originPath, destPath);
+    if (stat != OP_OK) {
+        return stat;
+    }
+
+    stat = this->_removeFile(originPath);
+
+    return stat;
+}
+
+ArduinoFileSystem::Status ArduinoFileSystem::_getWorkingDirectory(char* path, FwSizeType bufferSize) {
+    return Status::NOT_SUPPORTED;
+}
+
+ArduinoFileSystem::Status ArduinoFileSystem::_changeWorkingDirectory(const char* path) {
+    return Status::NOT_SUPPORTED;
+}
+
+ArduinoFileSystem::Status ArduinoFileSystem::_getFreeSpace(const char* path, FwSizeType& totalBytes, FwSizeType& freeBytes) {
+    return Status::NOT_SUPPORTED;
+}
+
+FileSystemHandle* ArduinoFileSystem::getHandle() {
+    return &this->m_handle;
+}
+
+} // namespace Arduino
+} // namespace Os

--- a/Arduino/Os/FileSystem.hpp
+++ b/Arduino/Os/FileSystem.hpp
@@ -1,0 +1,111 @@
+// ======================================================================
+// \title Os/Arduino/FileSystem.hpp
+// \brief Arduino fileSystem definitions for Os::FileSystem
+// ======================================================================
+#ifndef OS_ARDUINO_FILESYSTEM_HPP
+#define OS_ARDUINO_FILESYSTEM_HPP
+
+#include "Os/FileSystem.hpp"
+#include <SD.h>
+
+namespace Os {
+namespace Arduino {
+
+struct ArduinoFileSystemHandle : public FileSystemHandle {};
+
+//! \brief Arduino implementation of Os::FileSystem
+//!
+//! Arduino implementation of `FileSystemInterface` for use as a delegate class handling error-only fileSystem operations.
+//!
+class ArduinoFileSystem : public FileSystemInterface {
+  public:
+    //! \brief constructor
+    ArduinoFileSystem() = default;
+
+    //! \brief destructor
+    ~ArduinoFileSystem() override = default;
+
+
+    // ------------------------------------------------------------
+    // Implementation-specific FileSystem member functions
+    // ------------------------------------------------------------
+
+    //! \brief Remove a directory at the specified path
+    //!
+    //! It is invalid to pass `nullptr` as the path.
+    //!
+    //! \param path The path of the directory to remove
+    //! \return Status of the operation
+    Status _removeDirectory(const char* path) override;
+
+    //! \brief Remove a file at the specified path
+    //!
+    //! It is invalid to pass `nullptr` as the path.
+    //!
+    //! \param path The path of the file to remove
+    //! \return Status of the operation
+    Status _removeFile(const char* path) override;
+
+    //! \brief Rename a file from source to destination
+    //! 
+    //! If the rename fails due to a cross-device operation, this function should return EXDEV_ERROR
+    //! and moveFile can be used instead to force a copy-and-remove.
+    //!
+    //! It is invalid to pass `nullptr` as sourcePath or destPath.
+    //!
+    //! \param sourcePath The path of the source file
+    //! \param destPath The path of the destination file
+    //! \return Status of the operation
+    Status _rename(const char* sourcePath, const char* destPath) override;
+
+    //! \brief Get filesystem free and total space in bytes on the filesystem containing the specified path
+    //!
+    //! It is invalid to pass `nullptr` as the path.
+    //!
+    //! \param path The path on the filesystem to query
+    //! \param totalBytes Reference to store the total bytes on the filesystem
+    //! \param freeBytes Reference to store the free bytes on the filesystem
+    //! \return Status of the operation
+    Status _getFreeSpace(const char* path, FwSizeType& totalBytes, FwSizeType& freeBytes) override;
+
+    //! \brief Get the current working directory
+    //!
+    //! Writes the current working directory path to the provided buffer of size bufferSize.
+    //! If the buffer is too small to hold the full path, the function will return BUFFER_TOO_SMALL.
+    //!
+    //! It is invalid to pass `nullptr` as the path.
+    //! It is invalid to pass a bufferSize of 0.
+    //!
+    //! \param path Buffer to store the current working directory path
+    //! \param bufferSize Size of the buffer
+    //! \return Status of the operation
+    Status _getWorkingDirectory(char* path, FwSizeType bufferSize) override;
+
+    //! \brief Change the current working directory to the specified path
+    //!
+    //! It is invalid to pass `nullptr` as the path.
+    //!
+    //! \param path The path of the new working directory
+    //! \return Status of the operation
+    Status _changeWorkingDirectory(const char* path) override;
+
+
+
+    //! \brief returns the raw fileSystem handle
+    //!
+    //! Gets the raw fileSystem handle from the implementation. Note: users must include the implementation specific
+    //! header to make any real use of this handle. Otherwise it//!must* be passed as an opaque type.
+    //!
+    //! \return raw fileSystem handle
+    //!
+    FileSystemHandle *getHandle() override;
+
+
+private:
+    //! FileSystem handle for PosixFileSystem
+    ArduinoFileSystemHandle m_handle;
+};
+
+} // namespace Arduino
+} // namespace Os
+#endif // OS_ARDUINO_FILESYSTEM_HPP

--- a/cmake/platform/ArduinoFw.cmake
+++ b/cmake/platform/ArduinoFw.cmake
@@ -8,8 +8,17 @@ endif()
 
 set(CMAKE_EXECUTABLE_SUFFIX "${FPRIME_ARDUINO_EXECUTABLE_SUFFIX}" CACHE INTERNAL "" FORCE)
 
+# Check if Arduino Libraries Installed
+arduino_lib_installed("SD" LIB_SD_INSTALLED)
+
 # Add FPrime OSAL Implementations
-choose_fprime_implementation(Os/File Os_File_Stub)
+if (LIB_SD_INSTALLED)
+    message(STATUS "[fprime-arduino] SD Library found. Including SD File OS")
+    choose_fprime_implementation(Os/File Os_File_Arduino)
+else()
+    message(STATUS "[fprime-arduino] SD Library not found. Including Stub File OS")
+    choose_fprime_implementation(Os/File Os_File_Stub)
+endif()
 choose_fprime_implementation(Os/Queue Os_Generic_PriorityQueue)
 
 # Add Baremetal OSAL Implementations

--- a/cmake/toolchain/support/arduino-support.cmake
+++ b/cmake/toolchain/support/arduino-support.cmake
@@ -113,6 +113,53 @@ function(target_use_arduino_libraries)
     set(MOD_DEPS "${MOD_DEPS}" PARENT_SCOPE)
 endfunction(target_use_arduino_libraries)
 
+function(arduino_lib_installed)
+    # Extract the last argument as the result variable
+    list(LENGTH ARGN arg_count)
+    math(EXPR last_index "${arg_count} - 1")
+    list(GET ARGN ${last_index} result)
+
+    # Extract all other arguments as the libraries to check
+    list(REMOVE_AT ARGN ${last_index})
+    list(APPEND ARDUINO_LIBRARY_TO_CHECK ${ARGN})
+
+    find_program(ARDUINO_CLI NAMES arduino-cli)
+    if (NOT ARDUINO_CLI)
+        message(FATAL_ERROR "arduino-cli is required to be on PATH for arduino-support toolchain")
+    elseif (NOT DEFINED ARDUINO_FQBN)
+        message(FATAL_ERROR "Variable ARDUINO_FQDN must be set to use arduino-support")
+    endif()
+    set(EXECUTE_ARGS
+        "${ARDUINO_CLI}" "lib" "list" --fqbn "${ARDUINO_FQBN}"
+    )
+    # Execute the python wrapper
+    execute_process(COMMAND
+        ${EXECUTE_ARGS}
+        OUTPUT_VARIABLE RET_OUTPUT
+        RESULT_VARIABLE RET_CODE
+    )
+    # Split the output into lines
+    string(REGEX MATCHALL "[^\r\n]+" RET_OUTPUT_LINES "${RET_OUTPUT}")
+
+    # Extract the first column (library names) from each line
+    set(LIBRARY_NAMES "")
+    foreach(line IN LISTS RET_OUTPUT_LINES)
+        string(REGEX MATCH "^[^ ]+" library_name "${line}")
+        list(APPEND LIBRARY_NAMES "${library_name}")
+    endforeach()
+
+    set(is_installed TRUE)
+    foreach(LIBRARY IN LISTS ARDUINO_LIBRARY_TO_CHECK)
+        list(FIND LIBRARY_NAMES "${LIBRARY}" found_index)
+        if (found_index EQUAL -1)
+            set(is_installed FALSE)
+            break()
+        endif()
+    endforeach()
+
+    set(${result} ${is_installed} PARENT_SCOPE)
+endfunction(arduino_lib_installed)
+
 ####
 # Function `setup_arduino_linking`:
 #


### PR DESCRIPTION
Added File, FileSystem, and Directory using `<SD.h>` library.

Added new function `arduino_lib_installed` in `arduino-support.cmake` to check if a particular library is installed. This could probably be improved. 

If library `SD` is installed, use `Os_File_Arduino`. If not, use `Os_File_Stub`


Everything works, but `FileUplink` doesn't work currently with large files. I get `fileUplink.PacketOutOfOrder` and `fileUplink.BadChecksum` errors. Works for small files though.

`FileDownlink` works fine with large files.
