### PR TITLE
Fix to allow send_handler to return write_data status

### DIFF
--- a/Arduino/Drv/I2cDriver/I2cDriver.cpp
+++ b/Arduino/Drv/I2cDriver/I2cDriver.cpp
@@ -35,4 +35,17 @@ Drv::I2cStatus I2cDriver ::write_handler(const FwIndexType portNum, U32 addr, Fw
     return write_data(addr, serBuffer);
 }
 
+Drv::I2cStatus I2cDriver ::writeRead_handler(const FwIndexType portNum, U32 addr, Fw::Buffer& writeBuffer, Fw::Buffer& readBuffer) {
+    // Ensure buffer is not a nullptr
+    FW_ASSERT(writeBuffer.getData());
+    FW_ASSERT(readBuffer.getData());
+
+    Drv::I2cStatus status = write_data(addr, writeBuffer);
+    if (status == Drv::I2cStatus::I2C_OK) {
+        return read_data(addr, readBuffer);
+    }
+
+    return Drv::I2cStatus::I2C_OTHER_ERR;
+}
+
 }  // end namespace Arduino

--- a/Arduino/Drv/I2cDriver/I2cDriver.fpp
+++ b/Arduino/Drv/I2cDriver/I2cDriver.fpp
@@ -6,5 +6,7 @@ module Arduino {
 
         guarded input port read: Drv.I2c
 
+        guarded input port writeRead: Drv.I2cWriteRead
+
     }
 }

--- a/Arduino/Drv/I2cDriver/I2cDriver.hpp
+++ b/Arduino/Drv/I2cDriver/I2cDriver.hpp
@@ -71,6 +71,21 @@ namespace Arduino {
       */
       );
 
+      //! Handler implementation for writeRead
+      //!
+      Drv::I2cStatus writeRead_handler(
+          const FwIndexType portNum, /*!< The port number*/
+          U32 addr, /*!< 
+      I2C slave device address
+      */
+          Fw::Buffer &writeBuffer, /*!< 
+      Buffer with data to read/write to/from
+      */
+          Fw::Buffer &readBuffer /*!< 
+      Buffer with data to read/write to/from
+      */
+      );
+
       //! Stores the open wire port, POINTER_CAST so Linux and Ardunio may use different types
       void* m_port_pointer;
 

--- a/Arduino/Drv/StreamDriver/StreamDriver.cpp
+++ b/Arduino/Drv/StreamDriver/StreamDriver.cpp
@@ -14,7 +14,9 @@ namespace Arduino {
 // ----------------------------------------------------------------------
 
 StreamDriver ::StreamDriver(const char* compName)
-    : StreamDriverComponentBase(compName), m_port_number(0), m_port_pointer(nullptr) {}
+    : StreamDriverComponentBase(compName), m_port_number(0), m_port_pointer(nullptr) {
+        connection_status = ConnectionStatus::DISCONNECTED;
+    }
 
 StreamDriver ::~StreamDriver(void) {}
 
@@ -26,12 +28,20 @@ void StreamDriver::recvReturnIn_handler(FwIndexType portNum, Fw::Buffer& fwBuffe
     this->deallocate_out(0, fwBuffer);
 }
 
-Drv::ByteStreamStatus StreamDriver ::send_handler(const FwIndexType portNum, Fw::Buffer& serBuffer) {
-    (void) write_data(serBuffer);
-    return Drv::ByteStreamStatus::OP_OK;
+Drv::ByteStreamStatus StreamDriver ::send_handler(const FwIndexType portNum, Fw::Buffer& serBuffer) {    
+    Drv::ByteStreamStatus status = write_data(serBuffer);
+    if (status != Drv::ByteStreamStatus::OP_OK) {
+        connection_status = ConnectionStatus::DISCONNECTED;
+    }
+    return status;
 }
 
 void StreamDriver ::schedIn_handler(const FwIndexType portNum, U32 context) {
+    //If the connection was previously disconnected but is now available, re-configure
+    if ((connection_status == ConnectionStatus::DISCONNECTED) && Serial) {
+        connection_status = ConnectionStatus::CONNECTED;
+        configure(&Serial);
+    }
     if (not reinterpret_cast<Stream*>(m_port_pointer)->available()) {
         return;
     }

--- a/Arduino/Drv/StreamDriver/StreamDriver.hpp
+++ b/Arduino/Drv/StreamDriver/StreamDriver.hpp
@@ -61,10 +61,17 @@ class StreamDriver : public StreamDriverComponentBase {
                          U32 context                /*!< The call order*/
     );
 
+    enum ConnectionStatus {
+      DISCONNECTED,
+      CONNECTED
+    };
+
     //! Port number to open
     FwIndexType m_port_number;
     //! Stores the open stream port, POINTER_CAST so Linux and Ardunio may use different types
     void* m_port_pointer;
+    //! Stores the current connection status
+    ConnectionStatus connection_status;
 };
 
 }  // end namespace Arduino


### PR DESCRIPTION
This is a proposed fix that is related to the Queue Overflow problem in #48. This would revert the return value of send_handler in StreamDriver.cpp to be the actual value instead of always OP_OK no matter what happened with the write operation. To allow this, a connection status variable was added to track whether the connection is currently active. If the connection has not been active but a Serial connection is again detected, the StreamDriver configure function is used to reinitialize the serial connection and restart the telemetry flow.

Note that this proposed fix does not prevent the ComQueue from overflowing, it just makes it overflow more gracefully. By send_handler returning something other than OP_OK to ComQueue, that component will leave that message in the queue. I don't see a way to return a status that would tell ComQueue that the send was unsuccessful but that it is ok to remove the item from the queue anyway, which is what would prevent the queue from actually overflowing. 

So, when I disconnect and reconnect while I have the fprime-gds running, I actually see the warning hi QueueOverflow EVR like I did before. However, unlike before, data is still flowing and the ComQueue component isn't locked up waiting for Serial to be reinitialized.

As is, StreamDriver still works fine, but if people would prefer that it be possible for a proper status to be passed back to ComQueue this is a good way to do it in my opinion.